### PR TITLE
Bump version to 0.1.4 and fix invoice payment calculation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='speedapi_lib',
-    version='0.1.3',
+    version='0.1.4',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/speedapi_lib/speedapi.py
+++ b/speedapi_lib/speedapi.py
@@ -25,6 +25,10 @@ class SpeedAPI:
         return balance
 
     def pay_invoice(self, invoice: str) -> dict:
+        # First decode the invoice to get the amount
+        decoded_invoice = bolt11.decode(invoice)
+        amount_sats = decoded_invoice.amount_msat / 1000  # Convert from millisatoshi to satoshi
+        
         url = f"{self.base_url}/send"
         headers = {
             "accept": "application/json",
@@ -32,6 +36,7 @@ class SpeedAPI:
             "content-type": "application/json"
         }
         payload = {
+            "amount": amount_sats,
             "currency": "SATS",
             "withdraw_method": "lightning",
             "withdraw_request": invoice


### PR DESCRIPTION
Update the package version to 0.1.4 and ensure the invoice is correctly decoded to calculate the payment amount in the `pay_invoice` method.